### PR TITLE
The AtoN import REST endpoint was commented out, and needed to be re-…

### DIFF
--- a/niord-dk-aton-import/src/main/java/org/niord/importer/aton/AtonImportRestService.java
+++ b/niord-dk-aton-import/src/main/java/org/niord/importer/aton/AtonImportRestService.java
@@ -85,27 +85,27 @@ public class AtonImportRestService {
      * @param request the servlet request
      * @return a status
      */
-  //  @POST
-//    @Path("/upload-xls")
-//    @RequestBody(
-//            content = @Content(
-//                    mediaType = MediaType.MULTIPART_FORM_DATA,
-//                    schema = @Schema(implementation = org.niord.core.model.MultipartBody.class)
-//            )
-//    )
-//    @APIResponse(
-//            responseCode = "200",
-//            content = @Content(
-//                    mediaType = MediaType.TEXT_PLAIN,
-//                    schema = @Schema(implementation = String.class)
-//            )
-//    )
-//    @Consumes(MediaType.MULTIPART_FORM_DATA)
-//    @Produces(MediaType.TEXT_PLAIN)
-//    @Operation(description = "Performs the import operations from the AtoN xls/xlsx data files.")
-//    @RolesAllowed(Roles.ADMIN)
+    @POST
+    @Path("/upload-xls")
+    @RequestBody(
+            content = @Content(
+                    mediaType = MediaType.MULTIPART_FORM_DATA,
+                    schema = @Schema(implementation = org.niord.core.model.MultipartBody.class)
+            )
+    )
+    @APIResponse(
+            responseCode = "200",
+            content = @Content(
+                    mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(implementation = String.class)
+            )
+    )
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.TEXT_PLAIN)
+    @Operation(description = "Performs the import operations from the AtoN xls/xlsx data files.")
+    @RolesAllowed(Roles.ADMIN)
     public String importXls(@Parameter(name = "input", hidden = true)
-    @QueryParam("name")
+    //@QueryParam("name")
     MultipartFormDataInput input) throws Exception {
 
 

--- a/niord-dk-aton-import/src/main/java/org/niord/importer/aton/batch/BatchDkAisImportProcessor.java
+++ b/niord-dk-aton-import/src/main/java/org/niord/importer/aton/batch/BatchDkAisImportProcessor.java
@@ -21,6 +21,7 @@ import org.niord.core.aton.AtonTag;
 import org.niord.core.user.User;
 import org.slf4j.Logger;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
@@ -32,6 +33,7 @@ import jakarta.inject.Named;
  * http://wiki.openstreetmap.org/wiki/Key:seamark
  * and sub-pages.
  */
+@Dependent
 @Named
 public class BatchDkAisImportProcessor extends AbstractDkAtonImportProcessor {
 

--- a/niord-dk-aton-import/src/main/java/org/niord/importer/aton/batch/BatchDkAisImportReader.java
+++ b/niord-dk-aton-import/src/main/java/org/niord/importer/aton/batch/BatchDkAisImportReader.java
@@ -15,11 +15,13 @@
  */
 package org.niord.importer.aton.batch;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * Reads AIS from Excel
  */
+@Dependent
 @Named
 public class BatchDkAisImportReader extends AbstractDkAtonImportReader {
 

--- a/niord-dk-aton-import/src/main/java/org/niord/importer/aton/batch/BatchDkAtonImportProcessor.java
+++ b/niord-dk-aton-import/src/main/java/org/niord/importer/aton/batch/BatchDkAtonImportProcessor.java
@@ -20,6 +20,7 @@ import org.niord.core.aton.AtonNode;
 import org.niord.core.aton.AtonTag;
 import org.niord.core.user.User;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -36,6 +37,7 @@ import java.util.stream.Collectors;
  * http://wiki.openstreetmap.org/wiki/Key:seamark
  * and sub-pages.
  */
+@Dependent
 @Named
 public class BatchDkAtonImportProcessor extends AbstractDkAtonImportProcessor {
 

--- a/niord-dk-aton-import/src/main/java/org/niord/importer/aton/batch/BatchDkAtonImportReader.java
+++ b/niord-dk-aton-import/src/main/java/org/niord/importer/aton/batch/BatchDkAtonImportReader.java
@@ -15,11 +15,13 @@
  */
 package org.niord.importer.aton.batch;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * Reads AtoNs from the DB
  */
+@Dependent
 @Named
 public class BatchDkAtonImportReader extends AbstractDkAtonImportReader {
 

--- a/niord-dk-aton-import/src/main/java/org/niord/importer/aton/batch/BatchDkDgpsImportProcessor.java
+++ b/niord-dk-aton-import/src/main/java/org/niord/importer/aton/batch/BatchDkDgpsImportProcessor.java
@@ -20,6 +20,7 @@ import org.niord.core.aton.AtonTag;
 import org.niord.core.user.User;
 import org.slf4j.Logger;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
@@ -30,6 +31,7 @@ import jakarta.inject.Named;
  * http://wiki.openstreetmap.org/wiki/Key:seamark
  * and sub-pages.
  */
+@Dependent
 @Named
 public class BatchDkDgpsImportProcessor extends AbstractDkAtonImportProcessor {
 

--- a/niord-dk-aton-import/src/main/java/org/niord/importer/aton/batch/BatchDkDgpsImportReader.java
+++ b/niord-dk-aton-import/src/main/java/org/niord/importer/aton/batch/BatchDkDgpsImportReader.java
@@ -15,11 +15,13 @@
  */
 package org.niord.importer.aton.batch;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * Reads AIS from Excel
  */
+@Dependent
 @Named
 public class BatchDkDgpsImportReader extends AbstractDkAtonImportReader {
 

--- a/niord-dk-aton-import/src/main/java/org/niord/importer/aton/batch/BatchDkLightImportProcessor.java
+++ b/niord-dk-aton-import/src/main/java/org/niord/importer/aton/batch/BatchDkLightImportProcessor.java
@@ -21,6 +21,7 @@ import org.niord.core.aton.AtonTag;
 import org.niord.core.user.User;
 import org.slf4j.Logger;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
@@ -32,6 +33,7 @@ import jakarta.inject.Named;
  * http://wiki.openstreetmap.org/wiki/Key:seamark
  * and sub-pages.
  */
+@Dependent
 @Named
 public class BatchDkLightImportProcessor extends AbstractDkAtonImportProcessor {
 

--- a/niord-dk-aton-import/src/main/java/org/niord/importer/aton/batch/BatchDkLightImportReader.java
+++ b/niord-dk-aton-import/src/main/java/org/niord/importer/aton/batch/BatchDkLightImportReader.java
@@ -15,11 +15,13 @@
  */
 package org.niord.importer.aton.batch;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * Reads lights from the DB
  */
+@Dependent
 @Named
 public class BatchDkLightImportReader extends AbstractDkAtonImportReader {
 

--- a/niord-dk-aton-import/src/main/java/org/niord/importer/aton/batch/BatchDkRaconImportProcessor.java
+++ b/niord-dk-aton-import/src/main/java/org/niord/importer/aton/batch/BatchDkRaconImportProcessor.java
@@ -21,6 +21,7 @@ import org.niord.core.aton.AtonTag;
 import org.niord.core.user.User;
 import org.slf4j.Logger;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import java.util.regex.Matcher;
@@ -37,6 +38,7 @@ import java.util.regex.Pattern;
  * RACONs are also documented at:
  * http://wiki.openstreetmap.org/wiki/Key:radar_transponder
  */
+@Dependent
 @Named
 public class BatchDkRaconImportProcessor extends AbstractDkAtonImportProcessor {
 

--- a/niord-dk-aton-import/src/main/java/org/niord/importer/aton/batch/BatchDkRaconImportReader.java
+++ b/niord-dk-aton-import/src/main/java/org/niord/importer/aton/batch/BatchDkRaconImportReader.java
@@ -15,11 +15,13 @@
  */
 package org.niord.importer.aton.batch;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * Reads AIS from Excel
  */
+@Dependent
 @Named
 public class BatchDkRaconImportReader extends AbstractDkAtonImportReader {
 


### PR DESCRIPTION
The AtoN import REST endpoint was commented out, and needed to be re-enabled.

We also now need to add `@Dependent` to the batch components.

Quarkus's CDI container (ArC) uses `bean-discovery-mode=annotated` by default: a class only becomes a managed bean if it carries a bean-defining annotation — a scope or stereotype. `@Named` is a qualifier, not a scope, so these classes were invisible to the CDI container. When the Jakarta Batch engine resolved `ref="batchDkAisImportReader"` via `BeanManager.getBeans(…)` at runtime, the lookup returned nothing and the job failed.

Adding `@Dependent` provides the required scope annotation, registering the class as a CDI bean so the lookup succeeds.

`@Dependent` specifically is what the Jakarta Batch spec (JSR-352 §10.5) requires for batch artifacts — the runtime manages their lifecycle directly and must get the real instance, not a CDI proxy.

The original WildFly deployment used `bean-discovery-mode=all`, where every class is a candidate regardless of annotations, so `@Named` alone was sufficient. The Quarkus migration exposed the gap.